### PR TITLE
Add usage with async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install using npm:
 ## Usage
 
 ```js
-var delay = require('timeout-as-promise');
+const delay = require('timeout-as-promise');
 
 delay().then(function() {
     console.log('nextTick!');
@@ -37,6 +37,20 @@ Promise.resolve(42)
     .then(function(result) {
         console.log('result is ' + result); //=> 42
     });
+```
+
+### Or using async/await
+
+```js
+const delay = require('timeout-as-promise');
+
+async function stop() {
+    console.log('starting up');
+    await delay(2000);
+    console.log('2 seconds have passed');
+}
+
+stop();
 ```
 
 ## License


### PR DESCRIPTION
Added a usage example for async/await usage and I also changed the `var` to `const` due to const truly being constant in modern JS while `var` is re-assignable and you don't want to reassign a module import.

[More info on async/await and JS concurrency (youtube)](https://www.youtube.com/watch?v=NsQ2QIrQShU)

[Concerning `let`, `var` and `const` in the ES6 spec (medium)](https://medium.com/javascript-scene/javascript-es6-var-let-or-const-ba58b8dcde75)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.